### PR TITLE
Allow Avocado Saplings to be potted

### DIFF
--- a/src/main/java/com/ncpbails/culturaldelights/CulturalDelights.java
+++ b/src/main/java/com/ncpbails/culturaldelights/CulturalDelights.java
@@ -15,6 +15,7 @@ import net.minecraft.world.entity.animal.Pig;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.ComposterBlock;
+import net.minecraft.world.level.block.FlowerPotBlock;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.crafting.CompoundIngredient;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -76,9 +77,15 @@ public class CulturalDelights
     {
         event.enqueueWork(() -> {
             registerCompostables();
+            registerPottables();
             //registerAnimalFeeds();
         });
     }
+
+    public static void registerPottables() {
+        FlowerPotBlock pot = (FlowerPotBlock) Blocks.FLOWER_POT;
+        pot.addPlant(ModBlocks.AVOCADO_SAPLING.getId(), ModBlocks.POTTED_AVOCADO_SAPLING);
+}
 
     public static void registerCompostables() {
         // 30% chance

--- a/src/main/java/com/ncpbails/culturaldelights/block/ModBlocks.java
+++ b/src/main/java/com/ncpbails/culturaldelights/block/ModBlocks.java
@@ -48,6 +48,9 @@ public class ModBlocks {
             () -> new AvocadoPitBlock(new AvocadoPitGrower(), BlockBehaviour.Properties.copy(Blocks.OAK_SAPLING)), FarmersDelight.CREATIVE_TAB, false, 0);
     public static final RegistryObject<Block> AVOCADO_SAPLING = registerBlock("avocado_sapling",
             () -> new SaplingBlock(new AvocadoTreeGrower(), BlockBehaviour.Properties.copy(Blocks.OAK_SAPLING)), FarmersDelight.CREATIVE_TAB, true, 100);
+    public static final RegistryObject<FlowerPotBlock> POTTED_AVOCADO_SAPLING = registerBlockWithoutBlockItem("potted_avocado_sapling",
+            () -> new FlowerPotBlock(()-> (FlowerPotBlock) Blocks.FLOWER_POT, AVOCADO_SAPLING, BlockBehaviour.Properties.copy(Blocks.OAK_SAPLING)));
+
     public static final RegistryObject<Block> AVOCADO_LOG = registerBlock("avocado_log",
             () -> new RotatedPillarBlock(BlockBehaviour.Properties.copy(Blocks.JUNGLE_LOG)) {
                 @Override public boolean isFlammable(BlockState state, BlockGetter world, BlockPos pos, Direction face) { return true; }

--- a/src/main/resources/assets/culturaldelights/blockstates/potted_avocado_sapling.json
+++ b/src/main/resources/assets/culturaldelights/blockstates/potted_avocado_sapling.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "culturaldelights:block/potted_avocado_sapling"
+    }
+  }
+}

--- a/src/main/resources/assets/culturaldelights/models/block/potted_avocado_sapling.json
+++ b/src/main/resources/assets/culturaldelights/models/block/potted_avocado_sapling.json
@@ -1,0 +1,7 @@
+{
+  "parent": "minecraft:block/flower_pot_cross",
+  "textures": {
+    "plant": "culturaldelights:block/avocado_sapling"
+  },
+  "render_type":"cutout"
+}

--- a/src/main/resources/data/culturaldelights/loot_tables/blocks/potted_avocado_sapling.json
+++ b/src/main/resources/data/culturaldelights/loot_tables/blocks/potted_avocado_sapling.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1
+    },
+    {
+      "bonus_rolls": 0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "culturaldelights:avocado_sapling"
+        }
+      ],
+      "rolls": 1
+    }
+  ]
+}


### PR DESCRIPTION
Unlike other saplings, Avocado Saplings are not currently able to be placed in flower pots. This PR introduces a potted avocado sapling block to fix that.

This issue was first discovered in Raspberry Flavoured as https://github.com/cassiancc/Raspberry-Core/issues/13